### PR TITLE
Fixing camera shutter noises

### DIFF
--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -115,16 +115,6 @@ public struct CodeScannerView: UIViewControllerRepresentable {
     
 }
 
-public extension AVCaptureDevice {
-    
-    /// This returns the Ultra Wide Camera on capable devices and the default Camera for Video otherwise.
-    static var bestForVideo: AVCaptureDevice? {
-        let deviceHasUltraWideCamera = !AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInUltraWideCamera], mediaType: .video, position: .back).devices.isEmpty
-        return deviceHasUltraWideCamera ? AVCaptureDevice.default(.builtInUltraWideCamera, for: .video, position: .back) : AVCaptureDevice.default(for: .video)
-    }
-    
-}
-
 @available(macCatalyst 14.0, *)
 struct CodeScannerView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -37,6 +37,9 @@ public struct ScanResult {
     
     /// The image of the code that was matched
     public let image: UIImage?
+  
+    /// The corner coordinates of the scanned code.
+    public let corners: [CGPoint]
 }
 
 /// The operating mode for CodeScannerView.

--- a/Sources/CodeScanner/CodeScanner.swift
+++ b/Sources/CodeScanner/CodeScanner.swift
@@ -83,7 +83,7 @@ public struct CodeScannerView: UIViewControllerRepresentable {
         shouldVibrateOnSuccess: Bool = true,
         isTorchOn: Bool = false,
         isGalleryPresented: Binding<Bool> = .constant(false),
-        videoCaptureDevice: AVCaptureDevice? = AVCaptureDevice.default(for: .video),
+        videoCaptureDevice: AVCaptureDevice? = AVCaptureDevice.bestForVideo,
         completion: @escaping (Result<ScanResult, ScanError>) -> Void
     ) {
         self.codeTypes = codeTypes
@@ -111,6 +111,16 @@ public struct CodeScannerView: UIViewControllerRepresentable {
             isManualCapture: scanMode == .manual,
             isManualSelect: manualSelect
         )
+    }
+    
+}
+
+public extension AVCaptureDevice {
+    
+    /// This returns the Ultra Wide Camera on capable devices and the default Camera for Video otherwise.
+    static var bestForVideo: AVCaptureDevice? {
+        let deviceHasUltraWideCamera = !AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInUltraWideCamera], mediaType: .video, position: .back).devices.isEmpty
+        return deviceHasUltraWideCamera ? AVCaptureDevice.default(.builtInUltraWideCamera, for: .video, position: .back) : AVCaptureDevice.default(for: .video)
     }
     
 }

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -524,3 +524,14 @@ extension CodeScannerView.ScannerViewController: AVCapturePhotoCaptureDelegate {
     }
     
 }
+
+@available(macCatalyst 14.0, *)
+public extension AVCaptureDevice {
+    
+    /// This returns the Ultra Wide Camera on capable devices and the default Camera for Video otherwise.
+    static var bestForVideo: AVCaptureDevice? {
+        let deviceHasUltraWideCamera = !AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInUltraWideCamera], mediaType: .video, position: .back).devices.isEmpty
+        return deviceHasUltraWideCamera ? AVCaptureDevice.default(.builtInUltraWideCamera, for: .video, position: .back) : AVCaptureDevice.default(for: .video)
+    }
+    
+}

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -12,7 +12,7 @@ import UIKit
 @available(macCatalyst 14.0, *)
 extension CodeScannerView {
     
-    public class ScannerViewController: UIViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate, AVCaptureMetadataOutputObjectsDelegate {
+    public class ScannerViewController: UIViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate, AVCaptureMetadataOutputObjectsDelegate, UIAdaptivePresentationControllerDelegate {
         private let photoOutput = AVCapturePhotoOutput()
         private var isCapturing = false
         private var handler: ((UIImage) -> Void)?
@@ -46,6 +46,7 @@ extension CodeScannerView {
             isGalleryShowing = true
             let imagePicker = UIImagePickerController()
             imagePicker.delegate = self
+            imagePicker.presentationController?.delegate = self
             present(imagePicker, animated: true, completion: nil)
         }
         
@@ -84,6 +85,11 @@ extension CodeScannerView {
         public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
             isGalleryShowing = false
             dismiss(animated: true, completion: nil)
+        }
+
+        public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+            // Galery is no longer being presented
+            isGalleryShowing = false
         }
 
         #if targetEnvironment(simulator)

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -64,15 +64,16 @@ extension CodeScannerView {
                 let features = detector.features(in: ciImage)
 
                 for feature in features as! [CIQRCodeFeature] {
-                    qrCodeLink += feature.messageString!
+                    qrCodeLink = feature.messageString!
+                    if qrCodeLink == "" {
+                        didFail(reason: .badOutput)
+                    } else {
+                        let result = ScanResult(string: qrCodeLink, type: .qr, image: qrcodeImg)
+                        found(result)
+                    }
+
                 }
 
-                if qrCodeLink == "" {
-                    didFail(reason: .badOutput)
-                } else {
-                    let result = ScanResult(string: qrCodeLink, type: .qr, image: qrcodeImg)
-                    found(result)
-                }
             } else {
                 print("Something went wrong")
             }

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -68,7 +68,13 @@ extension CodeScannerView {
                     if qrCodeLink == "" {
                         didFail(reason: .badOutput)
                     } else {
-                        let result = ScanResult(string: qrCodeLink, type: .qr, image: qrcodeImg)
+                        let corners = [
+                            feature.bottomLeft,
+                            feature.bottomRight,
+                            feature.topRight,
+                            feature.topLeft
+                        ]
+                        let result = ScanResult(string: qrCodeLink, type: .qr, image: qrcodeImg, corners: corners)
                         found(result)
                     }
 
@@ -125,7 +131,7 @@ extension CodeScannerView {
             // Send back their simulated data, as if it was one of the types they were scanning for
             found(ScanResult(
                 string: parentView.simulatedData,
-                type: parentView.codeTypes.first ?? .qr, image: nil
+                type: parentView.codeTypes.first ?? .qr, image: nil, corners: []
             ))
         }
         
@@ -446,7 +452,7 @@ extension CodeScannerView {
                 isCapturing = true
                 
                 handler = { [self] image in
-                    let result = ScanResult(string: stringValue, type: readableObject.type, image: image)
+                    let result = ScanResult(string: stringValue, type: readableObject.type, image: image, corners: readableObject.corners)
                     
                     switch parentView.scanMode {
                     case .once:

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -491,7 +491,12 @@ extension CodeScannerView {
 
 @available(macCatalyst 14.0, *)
 extension CodeScannerView.ScannerViewController: AVCapturePhotoCaptureDelegate {
-    public func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+    
+    public func photoOutput(
+        _ output: AVCapturePhotoOutput,
+        didFinishProcessingPhoto photo: AVCapturePhoto,
+        error: Error?
+    ) {
         isCapturing = false
         guard let imageData = photo.fileDataRepresentation() else {
             print("Error while generating image from photo capture data.");
@@ -502,5 +507,20 @@ extension CodeScannerView.ScannerViewController: AVCapturePhotoCaptureDelegate {
             return
         }
         handler?(qrImage)
-     }
+    }
+    
+    public func photoOutput(
+        _ output: AVCapturePhotoOutput,
+        willCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings
+    ) {
+        AudioServicesDisposeSystemSoundID(1108)
+    }
+    
+    public func photoOutput(
+        _ output: AVCapturePhotoOutput,
+        didCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings
+    ) {
+        AudioServicesDisposeSystemSoundID(1108)
+    }
+    
 }

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -178,7 +178,18 @@ extension CodeScannerView {
         @objc func updateOrientation() {
             guard let orientation = view.window?.windowScene?.interfaceOrientation else { return }
             guard let connection = captureSession?.connections.last, connection.isVideoOrientationSupported else { return }
-            connection.videoOrientation = AVCaptureVideoOrientation(rawValue: orientation.rawValue) ?? .portrait
+            switch orientation {
+            case .portrait:
+                connection.videoOrientation = .portrait
+            case .landscapeLeft:
+                connection.videoOrientation = .landscapeLeft
+            case .landscapeRight:
+                connection.videoOrientation = .landscapeRight
+            case .portraitUpsideDown:
+                connection.videoOrientation = .portraitUpsideDown
+            default:
+                connection.videoOrientation = .portrait
+            }
         }
 
         override public func viewDidAppear(_ animated: Bool) {

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -94,7 +94,7 @@ extension CodeScannerView {
         }
 
         public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-            // Galery is no longer being presented
+            // Gallery is no longer being presented
             isGalleryShowing = false
         }
 


### PR DESCRIPTION
Autofocus on devices that are equipped with an Ultra Wide Camera seems to be off using the default Camera. This is why we select the Ultra Wide Camera per default now.

