### PR TITLE
: twostraws#85 unreliable torch

### DIFF
--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -22,6 +22,8 @@ extension CodeScannerView {
         var lastTime = Date(timeIntervalSince1970: 0)
         private let showViewfinder: Bool
         
+        let fallbackVideoCaptureDevice = AVCaptureDevice.default(for: .video)
+        
         private var isGalleryShowing: Bool = false {
             didSet {
                 // Update binding
@@ -145,7 +147,6 @@ extension CodeScannerView {
         
         var captureSession: AVCaptureSession?
         var previewLayer: AVCaptureVideoPreviewLayer!
-        let fallbackVideoCaptureDevice = AVCaptureDevice.default(for: .video)
 
         private lazy var viewFinder: UIImageView? = {
             guard let image = UIImage(named: "viewfinder", in: .module, with: nil) else {

--- a/Sources/CodeScanner/ScannerViewController.swift
+++ b/Sources/CodeScanner/ScannerViewController.swift
@@ -416,12 +416,14 @@ extension CodeScannerView {
         #endif
         
         func updateViewController(isTorchOn: Bool, isGalleryPresented: Bool, isManualCapture: Bool, isManualSelect: Bool) {
-            if let backCamera = AVCaptureDevice.default(for: AVMediaType.video),
-               backCamera.hasTorch
-            {
-                try? backCamera.lockForConfiguration()
-                backCamera.torchMode = isTorchOn ? .on : .off
-                backCamera.unlockForConfiguration()
+            guard let videoCaptureDevice = parentView.videoCaptureDevice ?? fallbackVideoCaptureDevice else {
+                return
+            }
+            
+            if videoCaptureDevice.hasTorch {
+                try? videoCaptureDevice.lockForConfiguration()
+                videoCaptureDevice.torchMode = isTorchOn ? .on : .off
+                videoCaptureDevice.unlockForConfiguration()
             }
             
             if isGalleryPresented && !isGalleryShowing {


### PR DESCRIPTION
Fixes an issue where the CaptureSession became unresponsive while the torch was on or where the CaptureSession wouldn't properly start at all when the torch was on by default.